### PR TITLE
Add attribution guidelines to code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,20 +4,62 @@ We value the participation of every member of our community and want to ensure a
 
 Kirstie Whitaker, founder and lead developer of the Brain Networks in Python project, members of the Whitaker lab, and contributors to the Brain Networks in Python project are dedicated to a ***harassment-free experience for everyone***, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age or religion. **We do not tolerate harassment by and/or of members of our community in any form**.
 
-We are particularly motivated to support new and/or anxious collaborators, people who are looking to learn and develop their skills, and anyone who has experienced discrimination in the past.
+*We are particularly motivated to support new and/or anxious collaborators, people who are looking to learn and develop their skills, and anyone who has experienced discrimination in the past.*
+
+## Our expectations
 
 To make clear what is expected, we ask all members of the community to conform to the following Code of Conduct.
 
 * All communication - online and in person - should be appropriate for a professional audience including people of many different backgrounds. Sexual language and imagery is not appropriate at any time.
 
-* Be kind to others. Do not insult or put down other contributers.
+* Be kind to others. Do not insult or put down other contributors.
 
 * Behave professionally. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate.
 
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
 Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of discussions, inappropriate physical contact, and unwelcome sexual attention.
 
+Examples of unacceptable behavior by community members include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
 ***Participants asked to stop any harassing behavior are expected to comply immediately.***
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Enforcement
 
 Members of the community who violate these rules - no matter how much they have contributed to the Whitaker lab, or how specialised their skill set - will be approached by Kirstie Whitaker. If inappropriate behaviour persists after a discussion with Kirstie, the contributer will be asked to discontinue their participation in Whitaker lab projects.
 
 **To report an issue** please contact [Kirstie Whitaker](https://github.com/KirstieJane). All communication will be treated as confidential.
+
+## Attribution
+
+This Code of Conduct was built on top of the [Mozilla Science Lab's][mozilla-science-home] [Code of Conduct][mozilla-science-coc] which is in the public domain under a [CC0 license][cc0-link]. It also incorporates part of the [Contributor Covenant][contributor-covenant-home], version 1.4, available at [http://contributor-covenant.org/version/1/4][contributor-covenant-version] and used under a [CC-BY 4.0][ccby-link] license.
+
+The Brain Networks in Python Code of Conduct was developed by [Kirstie Whitaker][kirstie-github] and is provided under a [CC-BY 4.0][ccby-link] license, which means that anyone can remix and reuse the content provided here, without seeking additional permission, so long as it is attributed back to the [Brain Networks in Python][bnip-repo] project. Please remember to also attribute the [Contributor Covenant][contributor-covenant-home].
+
+
+[contributor-covenant-home]: http://contributor-covenant.org
+[contributor-covenant-version]: http://contributor-covenant.org/version/1/4
+[ccby-link]: https://creativecommons.org/licenses/by/4.0
+[cc0-link]: https://creativecommons.org/publicdomain/zero/1.0
+[kirstie-github]: https://github.com/kirstiejane
+[bnip-repo]: https://github.com/WhitakerLab/BrainNetworksInPython
+[mozilla-science-home]: https://science.mozilla.org/
+[mozilla-science-coc]: https://github.com/mozillascience/code_of_conduct

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -46,7 +46,7 @@ Project maintainers have the right and responsibility to remove, edit, or reject
 
 Members of the community who violate these rules - no matter how much they have contributed to the Whitaker lab, or how specialised their skill set - will be approached by Kirstie Whitaker. If inappropriate behaviour persists after a discussion with Kirstie, the contributer will be asked to discontinue their participation in Whitaker lab projects.
 
-**To report an issue** please contact [Kirstie Whitaker](https://github.com/KirstieJane). All communication will be treated as confidential.
+**To report an issue** please contact [Kirstie Whitaker](https://github.com/KirstieJane) or [Isla Staden](https://github.com/Islast). All communication will be treated as confidential.
 
 ## Attribution
 


### PR DESCRIPTION
This partially fixes issue #34.