### PR TITLE
Get tests working for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
-  - "3.2"
-  - "3.3"
+    #  - "3.2" # scipy requires python >= 3.4
+    #  - "3.3"
   - "3.4"
   - "3.5"
   - "3.5-dev" # 3.5 development branch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pytest
-numpy
 pandas
 networkx==1.9
 python-louvain
+numpy
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pytest
 numpy
 pandas
-networkx
+networkx==1.9
 python-louvain
+scipy

--- a/wrappers/network_analysis_from_corrmat.py
+++ b/wrappers/network_analysis_from_corrmat.py
@@ -100,7 +100,11 @@ def read_in_data(corr_mat_file, names_file, centroids_file, names_308_style):
     '''
     # Load the input files
     M = np.loadtxt(corr_mat_file)
-    names = [ line.strip() for line in open(names_file) ]
+    # open the file in a context manager so the list comprehension
+    # iterates over the lines in the file (file will automatically
+    # be closed when the with block is finished
+    with open(names_file) as IN:
+        names = [ line.strip() for line in IN ]
     centroids = np.loadtxt(centroids_file)
 
     # If you have your names in names_308_style you need to strip the


### PR DESCRIPTION
<!---
This is a suggested pull request template for the BrainNetworksInPython. 
We don't mind whether or not you use it. It's just a list of useful 
questions to answer. :)
-->
- [x] I'm ready to merge
I can try to get the other python versions working as time permits

* **What's the context for this pull request?** 
_(this is a good place to reference any issues that this PR addresses)_

This PR fixes part of #32 but only for Python 3.6

* **What's new?**
I've added some specific version requirements which fixes some networkx compatibility issues. I've also added scipy to requirements.txt and removed python 3.2 and 3.2 from Travis as they are incompatible with scipy.

* **What should a reviewer feedback on?**
The changes are minimal. Just double check that the CI tests pass again before merging.

* **Does anything need to be updated after merge?** 
_(e.g the wiki or the WhitakerLab website)_

Probably not. Perhaps being explicit about what versions are required in any docs would help.
