### PR TITLE
Remove dev python versions from travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,9 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
-  - "3.5-dev" # 3.5 development branch
   - "3.6"
-  - "3.6-dev" # 3.6 development branch
-  - "3.7-dev" # 3.7 development branch
 # command to install dependencies
 install:
-  - pip install .
   - pip install -r requirements.txt
 # command to run tests
 script:


### PR DESCRIPTION
<!---
This is a suggested pull request template for the BrainNetworksInPython. 
We don't mind whether or not you use it. It's just a list of useful 
questions to answer. :)
-->
- [x] I'm ready to merge

* **What's the context for this pull request?** 
_(this is a good place to reference any issues that this PR addresses)_
#32

* **What's new?**
 I'm removing the development versions of python from the Travis setup
I'm also removing an unnecessary line "pip install ." left over from some copy pasting

* **What should a reviewer feedback on?**
If they object to me removing the dev versions of python

* **Does anything need to be updated after merge?** 
_(e.g the wiki or the WhitakerLab website)_
Not for now, although when we get around to writing up where we are with testing, this is relevant information