### PR TITLE
[FIX] Require specific pandas version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytest
-pandas
+pandas<=0.22.0
 python-louvain
 numpy
 scipy


### PR DESCRIPTION
- [x] I'm ready to merge

* **What's the context for this pull request?** 
This addresses #68, regarding Travis CI failing for Python 3.6.

* **What's new?**
The `pandas` module rolled out a new version (0.23.0) on 2018-05-16, which included breaking changes for `BrainNetworksInPython`. This PR ensures that the `requirements.txt` file in the current repository specifies the installed verison of `pandas` must be <=0.22.0.

* **What should a reviewer give feedback on?**
Since I only changed a single line in the `requirements.txt` file, hopefully not too much! Making sure I spelled things correctly, I suppose :smile: 

* **Does anything need to be updated after merge?** 
I don't think so!
